### PR TITLE
feat: 広告のライフサイクルを修正しv2.1.0にバージョンアップした

### DIFF
--- a/RouletteArrow.xcodeproj/project.pbxproj
+++ b/RouletteArrow.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kanbe1365.RouletteArrow;
 				PRODUCT_NAME = RouletteArrow;
 				SDKROOT = iphoneos;
@@ -655,7 +655,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kanbe1365.RouletteArrow;
 				PRODUCT_NAME = RouletteArrow;
 				SDKROOT = iphoneos;

--- a/RouletteArrow.xcodeproj/xcshareddata/xcschemes/RouletteArrow (iOS).xcscheme
+++ b/RouletteArrow.xcodeproj/xcshareddata/xcschemes/RouletteArrow (iOS).xcscheme
@@ -42,7 +42,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Shared/InterstitialAd.swift
+++ b/Shared/InterstitialAd.swift
@@ -8,9 +8,28 @@
 import GoogleMobileAds
 
 class Interstitial: NSObject, FullScreenContentDelegate {
+    /// 使用する広告ユニットID。
+    /// DEBUG ビルド（Xcode 実行）では Google 公式のテスト用 ID を使い、
+    /// Release ビルド（App Store 配布）では本番 ID を使う。
+    /// 手動でテスト広告に固定したいときは、下の #if DEBUG を無視して
+    /// テスト用 ID をそのまま返すよう一時的に書き換えればよい。
+    private static let productionAdUnitID = "ca-app-pub-3155724310732667/6815701656"
+    /// Google 公式のインタースティシャル用テスト ID（誤クリックでもアカウント影響なし）
+    private static let testAdUnitID = "ca-app-pub-3940256099942544/4411468910"
+
+    private static var adUnitID: String {
+        #if DEBUG
+        return testAdUnitID
+        #else
+        return productionAdUnitID
+        #endif
+    }
+
     var interstitialAd: InterstitialAd?
     private var retryCount = 0
     private let maxRetryCount = 5
+    /// 読み込み処理が進行中かどうか（多重ロード防止）
+    private var isLoading = false
 
     override init() {
         super.init()
@@ -18,7 +37,11 @@ class Interstitial: NSObject, FullScreenContentDelegate {
 
     // 広告の読み込み
     func loadInterstitial() {
-        InterstitialAd.load(with: "ca-app-pub-3940256099942544/4411468910", request: Request()) { (ad, error) in
+        // すでに広告を保持している、または読み込み中なら何もしない（多重リクエスト防止）
+        guard interstitialAd == nil, !isLoading else { return }
+        isLoading = true
+        InterstitialAd.load(with: Self.adUnitID, request: Request()) { (ad, error) in
+            self.isLoading = false
             if let error = error {
                 print("読み込みに失敗しました: \(error.localizedDescription)")
                 self.retryLoadInterstitial()
@@ -50,15 +73,18 @@ class Interstitial: NSObject, FullScreenContentDelegate {
         let scenes = UIApplication.shared.connectedScenes
         let windowScenes = scenes.first as? UIWindowScene
         let root = windowScenes?.keyWindow?.rootViewController
-        if let ad = interstitialAd {
-            ad.present(from: root!)
+        if let ad = interstitialAd, let root = root {
+            ad.present(from: root)
         } else {
+            // 準備ができていないときは今回は表示せず、次回に備えて読み込むだけ。
+            // （多重ロードは loadInterstitial 側のガードで防ぐ）
             print("広告の準備ができていませんでした")
             self.loadInterstitial()
         }
     }
-    // 失敗通知
+    // 失敗通知：使い捨てのため破棄して次回分を読み込む
     func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        self.interstitialAd = nil
         self.loadInterstitial()
     }
 
@@ -67,8 +93,10 @@ class Interstitial: NSObject, FullScreenContentDelegate {
         print("インタースティシャル広告を表示しました")
     }
 
-    // クローズ通知
+    // クローズ通知：使い捨てのため破棄して次回分を読み込む
     func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         print("インタースティシャル広告を閉じました")
+        self.interstitialAd = nil
+        self.loadInterstitial()
     }
 }


### PR DESCRIPTION
インタースティシャル広告を閉じた/表示失敗した後に再読み込みするようにし、
多重ロードを防止した。これにより広告リクエストの急増とマッチ率低下を解消した。
DEBUG/Releaseで広告ユニットIDを切り替えられるようにし本番IDを設定した。